### PR TITLE
Add `FluentLanguageLoader::current_languages`

### DIFF
--- a/i18n-embed/src/fluent.rs
+++ b/i18n-embed/src/fluent.rs
@@ -93,6 +93,16 @@ impl FluentLanguageLoader {
         }
     }
 
+    /// The languages associated with each actual loaded language bundle.
+    pub fn current_languages(&self) -> Vec<unic_langid::LanguageIdentifier> {
+        self.language_config
+            .read()
+            .language_bundles
+            .iter()
+            .map(|b| b.language.clone())
+            .collect()
+    }
+
     /// Get a localized message referenced by the `message_id`.
     pub fn get(&self, message_id: &str) -> String {
         self.get_args_concrete(message_id, HashMap::new())


### PR DESCRIPTION
This PR adds a handy function to `FluentLanguageLoader` to be able to inspect, at runtime, which actual languages were loaded.
