### PR TITLE
i18n-embed-fl: pin the dashmap version

### DIFF
--- a/i18n-embed-fl/Cargo.toml
+++ b/i18n-embed-fl/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["i18n.toml", "i18n/"]
 proc-macro = true
 
 [dependencies]
-dashmap = "4.0.0-rc6"
+dashmap = "= 4.0.0-rc6"
 find-crate = "0.6"
 fluent = "0.13"
 fluent-syntax = "0.10"


### PR DESCRIPTION
Hey there!

I noticed a transitive build failure in one of my projects because of this: you're currently using an `rc` for `dashmap` without pinning it, which means that Cargo applies semver and tries to use the highest consistent version. That version, in turn, has an API change that breaks your use of it.

The more permanent fix is probably to update your codebase to use the newer `dashmap` APIs, but this should suffice for a point fix.