### PR TITLE
Allow user enable the '--use-fuzzy' option for the 'msgfmt' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ po_dir = "i18n/po"
 # command. By default this is `output_dir/mo`.
 mo_dir = "i18n/mo"
 
+# (Optional) Enable the `--use-fuzzy` option for the `msgfmt` command. By
+# default this is false. If your .po file are copied from another project, you
+# may need to enable it.
+use_fuzzy = false
+
 # (Optional) Use the fluent localization system.
 [fluent]
 # (Required) The path to the assets directory.

--- a/i18n-build/src/gettext_impl/mod.rs
+++ b/i18n-build/src/gettext_impl/mod.rs
@@ -358,18 +358,22 @@ pub fn run_msgfmt(crt: &Crate, po_dir: &Path, mo_dir: &Path) -> Result<()> {
         let mo_file_path = mo_locale_dir.join(crt.module_name()).with_extension("mo");
 
         let mut msgfmt = Command::new(msgfmt_command_name);
-        msgfmt.args(&[
-            format!(
-                "--output-file={}",
-                mo_file_path
-                    .to_str()
-                    .expect("mo file path is not valid utf-8")
-            )
-            .as_str(),
+        let msgfmt_arg_output_file = format!(
+            "--output-file={}",
+            mo_file_path
+                .to_str()
+                .expect("mo file path is not valid utf-8")
+        );
+        let mut msgfmt_args = vec![
+            msgfmt_arg_output_file.as_str(),
             po_file_path
                 .to_str()
                 .expect("po file path is not valid utf-8"),
-        ]);
+        ];
+        if gettext_config.use_fuzzy {
+            msgfmt_args.push("--use-fuzzy");
+        }
+        msgfmt.args(&msgfmt_args);
 
         util::run_command_and_check_success(msgfmt_command_name, msgfmt)?;
     }

--- a/i18n-config/src/gettext.rs
+++ b/i18n-config/src/gettext.rs
@@ -51,6 +51,11 @@ pub struct GettextConfig {
     /// Path to where the mo files will be written to by the
     /// `msgfmt` command.
     mo_dir: Option<PathBuf>,
+    /// Enable the `--use-fuzzy` option for the `msgfmt` command.
+    ///
+    /// By default this is **false**.
+    #[serde(default)]
+    pub use_fuzzy: bool,
 }
 
 impl GettextConfig {


### PR DESCRIPTION
Hi @kellpossible 

Our rust project copy the .po file from iOS project. When run `cargo i18n`, the .po file like the following. So we should add `--use-fuzzy` option for `msgfmt` command.

```
#: src/main.rs:66
#, fuzzy
msgid "xxx"
msgstr "xxx"
```

Please review it. thank you.
