### PR TITLE
Method `with_bundles_mut`

### DIFF
--- a/i18n-embed/src/fluent.rs
+++ b/i18n-embed/src/fluent.rs
@@ -279,8 +279,19 @@ impl FluentLanguageLoader {
     ///
     /// Default: `true`.
     pub fn set_use_isolating(&self, value: bool) {
+        self.with_bundles_mut(|bundle| bundle.set_use_isolating(value));
+    }
+
+    /// Apply some configuration to each budle in this loader.
+    ///
+    /// **Note:** This function will have no effect if
+    /// [`LanguageLoader::load_languages`] has not been called first.
+    pub fn with_bundles_mut<F>(&self, f: F)
+    where
+        F: Fn(&mut FluentBundle<Arc<FluentResource>, IntlLangMemoizer>),
+    {
         for bundle in self.language_config.write().language_bundles.as_mut_slice() {
-            bundle.bundle.set_use_isolating(value);
+            f(&mut bundle.bundle);
         }
     }
 }


### PR DESCRIPTION
Add method `FluentLanguageLoader::with_bundles_mut`, taking a callback Fn and applying it to all loaded bundles.

Reimplement `set_use_isolating` by calling `with_bundles_mut`.

Fixes #75 .