### PR TITLE
Add FluentLanguageLoader::lang method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
+name = "arc-swap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +386,7 @@ dependencies = [
 name = "i18n-embed"
 version = "0.13.3"
 dependencies = [
+ "arc-swap",
  "doc-comment",
  "env_logger",
  "fluent",

--- a/i18n-embed/Cargo.toml
+++ b/i18n-embed/Cargo.toml
@@ -18,6 +18,7 @@ all-features = true
 maintenance = { status = "actively-developed" }
 
 [dependencies]
+arc-swap = "1.5.0"
 fluent = { version = "0.16", optional = true }
 fluent-langneg = "0.13"
 fluent-syntax = { version = "0.11", optional = true }

--- a/i18n-embed/src/fluent.rs
+++ b/i18n-embed/src/fluent.rs
@@ -313,7 +313,7 @@ impl FluentLanguageLoader {
         self.with_bundles_mut(|bundle| bundle.set_use_isolating(value));
     }
 
-    /// Apply some configuration to each budle in this loader.
+    /// Apply some configuration to each bundle in this loader.
     ///
     /// **Note:** This function will have no effect if
     /// [`LanguageLoader::load_languages`] has not been called first.

--- a/i18n-embed/src/traits.rs.bak
+++ b/i18n-embed/src/traits.rs.bak
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use fluent::FluentArgs;
+use unic_langid::{LanguageIdentifier, subtags::Language};
+
+use crate::I18nEmbedError;
+
+pub trait Loader {
+    fn reload(&self) -> Result<(), Box<I18nEmbedError>>;
+}
+
+pub trait CurrentLanguage {
+
+}
+
+pub trait IntoCurrentLanguage {
+    fn into_current_language(self) -> Box<dyn CurrentLanguage>;
+}
+
+pub struct LanguageSelection {
+    loader: Arc<dyn Loader>,
+    loader_rev: usize,
+    language_idents: Vec<LanguageIdentifier>,
+    language_indices: Vec<usize>,
+}
+
+pub struct StaticCurrentLanguage {   
+    selection: LanguageSelection;
+}
+
+impl StaticCurrentLanguage {
+    pub fn new(lang: &[&LanguageIdentifier]) -> Self {
+        // FIXME implement
+        unimplemented!()
+    }
+}
+
+impl CurrentLanguage for StaticCurrentLanguage {
+}
+
+impl IntoCurrentLanguage for &[&LanguageIdentifier] {
+    fn into_current_language(self) -> Box<dyn CurrentLanguage> {
+        Box::new(StaticCurrentLanguage::new(self))
+    }
+}
+
+
+pub struct Translator {
+}
+
+impl Translator {
+    pub fn new(&self, loader: Arc<dyn Loader>, lang: impl IntoCurrentLanguage) -> Self {
+        Self {
+            loader: 
+            language_idents: lang.iter().cloned().collect(),
+            language_indices: Vec::new(),
+            current_language: 
+        }
+    }
+    fn get(&self, message_id: &str, args: Option<FluentArgs>) {
+
+    }
+    /**
+     * Create a new translator with a different list of languages.
+     */
+    fn lang(&self, lang: impl IntoCurrentLanguage) -> Self {
+    }
+}
+
+
+
+/*
+
+    let loader = FluentLoader::new();
+    let translator = loader.translator(&["de", "en"]);
+*/

--- a/i18n-embed/tests/loader.rs
+++ b/i18n-embed/tests/loader.rs
@@ -201,10 +201,10 @@ mod fluent {
             .load_languages(&Localizations, &[&ru, &en_gb])
             .unwrap();
 
-        let msg = loader.get_lang(&[&ru], "only-ru");
+        let msg = loader.lang(&[&ru]).get("only-ru");
         assert_eq!("только русский", msg);
 
-        let msg = loader.get_lang(&[&ru], "only-gb");
+        let msg = loader.lang(&[&ru]).get("only-gb");
         assert_eq!("only GB (US Version)", msg);
     }
 
@@ -225,7 +225,7 @@ mod fluent {
             "argTwo" => "2",
         };
 
-        let msg = loader.get_lang_args(&[&ru], "multi-line-args", args);
+        let msg = loader.lang(&[&ru]).get_args("multi-line-args", args);
         assert_eq!(
             "Это многострочное сообщение с параметрами.\n\n\
             \u{2068}1\u{2069}\n\n\
@@ -248,10 +248,10 @@ mod fluent {
             .load_languages(&Localizations, &[&ru, &en_gb])
             .unwrap();
 
-        let msg = loader.get_lang(&[&ru, &en_gb], "only-gb");
+        let msg = loader.lang(&[&ru, &en_gb]).get("only-gb");
         assert_eq!("only GB", msg);
 
-        let msg = loader.get_lang(&[&ru, &en_gb], "only-us");
+        let msg = loader.lang(&[&ru, &en_gb]).get("only-us");
         assert_eq!("only US", msg);
     }
 
@@ -271,10 +271,12 @@ mod fluent {
             "userName" => "username",
         };
 
-        let msg = loader.get_lang_args(&[&ru], "only-gb-args", args.clone());
+        let msg = loader.lang(&[&ru]).get_args("only-gb-args", args.clone());
         assert_eq!("Hello \u{2068}username\u{2069}! (US Version)", msg);
 
-        let msg = loader.get_lang_args(&[&ru, &en_gb], "only-gb-args", args.clone());
+        let msg = loader
+            .lang(&[&ru, &en_gb])
+            .get_args("only-gb-args", args.clone());
         assert_eq!("Hello \u{2068}username\u{2069}!", msg);
     }
 }


### PR DESCRIPTION
This is an alternative implementation for #59 and is based on the code from #84.

This PR adds a single new method:

- lang

This methods allows creating a shallow copy of the `FluentLanguageLoader` which can than be used just like the original loader but with a different current language setting. That makes it possible to use the `fl!` macro without any changes and is a far more elegant implementation than adding multiple `get_lang*` methods as done in #84.

For a future change I'd like to remove the `RwLock` and change that to a builder pattern. e.g. while building the loader you can still access the bundles in a mutable way but once the build is complete the internal language config is locked in and can't be changed anymore. That would get rid of locking primitive which is there just because of the `set_use_isolating` and `with_bundles_mut` methods.

This PR doesn't change the public API so it is a non-breaking change just like the other PR.