### PR TITLE
Enable ergonomic interaction with Fluent attributes

### DIFF
--- a/i18n-embed-fl/i18n/en-US/i18n_embed_fl.ftl
+++ b/i18n-embed-fl/i18n/en-US/i18n_embed_fl.ftl
@@ -1,3 +1,6 @@
 hello-world = Hello World!
 hello-arg = Hello {$name}!
+    .attr = Hello {$name}'s attribute!
 hello-arg-2 = Hello {$name1} and {$name2}!
+hello-attr = Uninspiring.
+    .text = Hello, attribute!

--- a/i18n-embed-fl/tests/fl_macro.rs
+++ b/i18n-embed-fl/tests/fl_macro.rs
@@ -67,3 +67,26 @@ fn with_one_arg_lit() {
         fl!(loader, "hello-arg", name = "Bob")
     );
 }
+
+#[test]
+fn with_attr() {
+    let loader: FluentLanguageLoader = fluent_language_loader!();
+    loader
+        .load_languages(&Localizations, &[loader.fallback_language()])
+        .unwrap();
+
+    pretty_assertions::assert_eq!("Hello, attribute!", fl!(loader, "hello-attr", "text"));
+}
+
+#[test]
+fn with_attr_and_args() {
+    let loader: FluentLanguageLoader = fluent_language_loader!();
+    loader
+        .load_languages(&Localizations, &[loader.fallback_language()])
+        .unwrap();
+
+    pretty_assertions::assert_eq!(
+        "Hello \u{2068}Bob\u{2069}'s attribute!",
+        fl!(loader, "hello-arg", "attr", name = "Bob")
+    );
+}

--- a/i18n-embed/i18n/ftl/en-GB/test.ftl
+++ b/i18n-embed/i18n/ftl/en-GB/test.ftl
@@ -2,3 +2,7 @@ hello-world = Hello World Localisation!
 only-gb = only GB
 only-gb-args = Hello {$userName}!
 different-args = this message has {$different} {$args} in different languages
+with-attr = Hello
+    .attr = World!
+with-attr-and-args = Hello
+    .who = {$name}!

--- a/i18n-embed/i18n/ftl/en-US/test.ftl
+++ b/i18n-embed/i18n/ftl/en-US/test.ftl
@@ -21,3 +21,7 @@ multi-line-args =
     { $argTwo }
 
     Finished!
+with-attr = Hello
+    .attr = World (US version)!
+with-attr-and-args = Hello
+    .who = {$name}!

--- a/i18n-embed/tests/loader.rs
+++ b/i18n-embed/tests/loader.rs
@@ -71,6 +71,28 @@ mod fluent {
     }
 
     #[test]
+    fn attr() {
+        setup();
+        let en_us: LanguageIdentifier = "en-US".parse().unwrap();
+        let loader = FluentLanguageLoader::new("test", en_us.clone());
+        loader.load_languages(&Localizations, &[&en_us]).unwrap();
+        pretty_assertions::assert_eq!("World (US version)!", loader.get_attr("with-attr", "attr"));
+    }
+
+    #[test]
+    fn attr_with_args() {
+        setup();
+        let en_us: LanguageIdentifier = "en-US".parse().unwrap();
+        let en_gb: LanguageIdentifier = "en-GB".parse().unwrap();
+        let loader = FluentLanguageLoader::new("test", en_us.clone());
+        loader.load_languages(&Localizations, &[&en_gb]).unwrap();
+        let args = maplit::hashmap! {
+            "name" => "Joe Doe"
+        };
+        pretty_assertions::assert_eq!("\u{2068}Joe Doe\u{2069}!", loader.get_attr_args("with-attr-and-args", "who", args));
+    }
+
+    #[test]
     fn has() {
         setup();
         let en_us: LanguageIdentifier = "en-US".parse().unwrap();


### PR DESCRIPTION
Refs #96 Various changes to i18n-embed and i18n-embed-fl enable ergonomic interaction with Fluent attributes.

Changes include:
- Added methods to the `FluentLanguageLoader` to mirror the methods used to access `FluentMessages`,
- Added `FluentLanguageLoader::has_attr()` to enable verifying if an attribute is present in any language for the given message,
- Tweaked the `fl!()` macro definition such that it optionally accepts an attribute ID in addition to a message ID and arguments,
- Implemented compile-time verification of attributes,
- Added unit tests to verify the newly implemented changes work.