### PR TITLE
Re-implementation of #59 (a rebase and cleanup of #88)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +446,7 @@ dependencies = [
 name = "i18n-embed"
 version = "0.13.5"
 dependencies = [
+ "arc-swap",
  "doc-comment",
  "env_logger",
  "fluent",

--- a/i18n-embed/CHANGELOG.md
+++ b/i18n-embed/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog for `i18n-embed`
 
+## v0.13.6
+
+### New Features
+
++ A single new method called `FluentLanguageLoader::lang()` thanks to [@bikeshedder](https://github.com/bikeshedder)!
+
+This methods allows creating a shallow copy of the
+FluentLanguageLoader which can than be used just like the original
+loader but with a different current language setting. That makes it
+possible to use the fl! macro without any changes and is a far more
+elegant implementation than adding multiple get_lang* methods as
+done in #84.
+
+### Deprecated
+
++ `FluentLanguageLoader::get_lang*` methods have been deprecated in favour of `FluentLanguageLoader::lang()`.
+
 ## v0.13.5
 
 ### New Features

--- a/i18n-embed/Cargo.toml
+++ b/i18n-embed/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 fluent = { version = "0.16", optional = true }
+arc-swap = "1.6"
 fluent-langneg = "0.13"
 fluent-syntax = { version = "0.11", optional = true }
 gettext_system = { package = "gettext", version = "0.4", optional = true }

--- a/i18n-embed/tests/loader.rs
+++ b/i18n-embed/tests/loader.rs
@@ -215,7 +215,7 @@ mod fluent {
     }
 
     #[test]
-    fn get_lang_default_fallback() {
+    fn lang_get_default_fallback() {
         setup();
         let ru: LanguageIdentifier = "ru".parse().unwrap();
         let en_gb: LanguageIdentifier = "en-GB".parse().unwrap();
@@ -226,15 +226,15 @@ mod fluent {
             .load_languages(&Localizations, &[&ru, &en_gb])
             .unwrap();
 
-        let msg = loader.get_lang(&[&ru], "only-ru");
+        let msg = loader.lang(&[&ru]).get("only-ru");
         assert_eq!("только русский", msg);
 
-        let msg = loader.get_lang(&[&ru], "only-gb");
+        let msg = loader.lang(&[&ru]).get("only-gb");
         assert_eq!("only GB (US Version)", msg);
     }
 
     #[test]
-    fn get_lang_args_default_fallback() {
+    fn lang_get_args_default_fallback() {
         setup();
         let ru: LanguageIdentifier = "ru".parse().unwrap();
         let en_gb: LanguageIdentifier = "en-GB".parse().unwrap();
@@ -250,7 +250,7 @@ mod fluent {
             "argTwo" => "2",
         };
 
-        let msg = loader.get_lang_args(&[&ru], "multi-line-args", args);
+        let msg = loader.lang(&[&ru]).get_args("multi-line-args", args);
         assert_eq!(
             "Это многострочное сообщение с параметрами.\n\n\
             \u{2068}1\u{2069}\n\n\
@@ -262,7 +262,7 @@ mod fluent {
     }
 
     #[test]
-    fn get_lang_custom_fallback() {
+    fn lang_get_custom_fallback() {
         setup();
         let ru: LanguageIdentifier = "ru".parse().unwrap();
         let en_gb: LanguageIdentifier = "en-GB".parse().unwrap();
@@ -273,15 +273,15 @@ mod fluent {
             .load_languages(&Localizations, &[&ru, &en_gb])
             .unwrap();
 
-        let msg = loader.get_lang(&[&ru, &en_gb], "only-gb");
+        let msg = loader.lang(&[&ru, &en_gb]).get("only-gb");
         assert_eq!("only GB", msg);
 
-        let msg = loader.get_lang(&[&ru, &en_gb], "only-us");
+        let msg = loader.lang(&[&ru, &en_gb]).get("only-us");
         assert_eq!("only US", msg);
     }
 
     #[test]
-    fn get_lang_args_custom_fallback() {
+    fn lang_get_args_custom_fallback() {
         setup();
         let ru: LanguageIdentifier = "ru".parse().unwrap();
         let en_gb: LanguageIdentifier = "en-GB".parse().unwrap();
@@ -296,10 +296,12 @@ mod fluent {
             "userName" => "username",
         };
 
-        let msg = loader.get_lang_args(&[&ru], "only-gb-args", args.clone());
+        let msg = loader.lang(&[&ru]).get_args("only-gb-args", args.clone());
         assert_eq!("Hello \u{2068}username\u{2069}! (US Version)", msg);
 
-        let msg = loader.get_lang_args(&[&ru, &en_gb], "only-gb-args", args.clone());
+        let msg = loader
+            .lang(&[&ru, &en_gb])
+            .get_args("only-gb-args", args.clone());
         assert_eq!("Hello \u{2068}username\u{2069}!", msg);
     }
 }


### PR DESCRIPTION
Re-implementation of #59 (a rebase and cleanup of #88) Many thanks to @bikeshedder  for doing most of the work here.

Adds a single new method lang.

This methods allows creating a shallow copy of the FluentLanguageLoader which can than be used just like the original loader but with a different current language setting. That makes it possible to use the fl! macro without any changes and is a far more elegant implementation than adding multiple get_lang* methods as done in #84.