### PR TITLE
Config option to specify domain name

### DIFF
--- a/i18n-config/src/fluent.rs
+++ b/i18n-config/src/fluent.rs
@@ -11,6 +11,8 @@ pub struct FluentConfig {
     /// like so: `assets_dir/{language}/{domain}.ftl`
     pub assets_dir: PathBuf,
 
-    /// (Optional) domain
+    /// (Optional) Domain name to override default value (i.e. package name)
+    /// The paths inside the assets directory should be  structured
+    /// like so: `assets_dir/{language}/{domain}.ftl` 
     pub domain: Option<String>,
 }

--- a/i18n-config/src/fluent.rs
+++ b/i18n-config/src/fluent.rs
@@ -13,6 +13,6 @@ pub struct FluentConfig {
 
     /// (Optional) Domain name to override default value (i.e. package name)
     /// The paths inside the assets directory should be  structured
-    /// like so: `assets_dir/{language}/{domain}.ftl` 
+    /// like so: `assets_dir/{language}/{domain}.ftl`
     pub domain: Option<String>,
 }

--- a/i18n-config/src/fluent.rs
+++ b/i18n-config/src/fluent.rs
@@ -10,4 +10,7 @@ pub struct FluentConfig {
     /// The paths inside the assets directory should be  structured
     /// like so: `assets_dir/{language}/{domain}.ftl`
     pub assets_dir: PathBuf,
+
+    /// (Optional) domain
+    pub domain: Option<String>,
 }

--- a/i18n-embed/i18n-embed-impl/src/lib.rs
+++ b/i18n-embed/i18n-embed-impl/src/lib.rs
@@ -128,8 +128,11 @@ pub fn fluent_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenSt
         &config.fallback_language.to_string(),
         proc_macro2::Span::call_site(),
     );
-    
-    let domain_str = config.fluent.and_then(|f| f.domain).unwrap_or(current_crate_package.name);
+
+    let domain_str = config
+        .fluent
+        .and_then(|f| f.domain)
+        .unwrap_or(current_crate_package.name);
     let domain = syn::LitStr::new(&domain_str, proc_macro2::Span::call_site());
 
     let gen = quote::quote! {

--- a/i18n-embed/i18n-embed-impl/src/lib.rs
+++ b/i18n-embed/i18n-embed-impl/src/lib.rs
@@ -85,7 +85,6 @@ pub fn gettext_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenS
 pub fn fluent_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let manifest = find_crate::Manifest::new().expect("Error reading Cargo.toml");
     let current_crate_package = manifest.crate_package().expect("Error reading Cargo.toml");
-    // let domain = syn::LitStr::new(&current_crate_package.name, proc_macro2::Span::call_site());
 
     // Special case for when this macro is invoked in i18n-embed tests/docs
     let i18n_embed_crate_name = if current_crate_package.name == "i18n_embed" {

--- a/i18n-embed/i18n-embed-impl/src/lib.rs
+++ b/i18n-embed/i18n-embed-impl/src/lib.rs
@@ -85,7 +85,7 @@ pub fn gettext_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenS
 pub fn fluent_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let manifest = find_crate::Manifest::new().expect("Error reading Cargo.toml");
     let current_crate_package = manifest.crate_package().expect("Error reading Cargo.toml");
-    let domain = syn::LitStr::new(&current_crate_package.name, proc_macro2::Span::call_site());
+    // let domain = syn::LitStr::new(&current_crate_package.name, proc_macro2::Span::call_site());
 
     // Special case for when this macro is invoked in i18n-embed tests/docs
     let i18n_embed_crate_name = if current_crate_package.name == "i18n_embed" {
@@ -128,6 +128,9 @@ pub fn fluent_language_loader(_: proc_macro::TokenStream) -> proc_macro::TokenSt
         &config.fallback_language.to_string(),
         proc_macro2::Span::call_site(),
     );
+    
+    let domain_str = config.fluent.and_then(|f| f.domain).unwrap_or(current_crate_package.name);
+    let domain = syn::LitStr::new(&domain_str, proc_macro2::Span::call_site());
 
     let gen = quote::quote! {
         #i18n_embed_crate_ident::fluent::FluentLanguageLoader::new(


### PR DESCRIPTION
close #39 

`FluentConfig` now has domain field
``` rust
pub domain: Option<String>
```

If present, it overrides the default domain name