### PR TITLE
Relax arc-swap dependency

### DIFF
--- a/i18n-embed/Cargo.toml
+++ b/i18n-embed/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 fluent = { version = "0.16", optional = true }
-arc-swap = { version = "1.6", optional = true }
+arc-swap = { version = "1", optional = true }
 fluent-langneg = "0.13"
 fluent-syntax = { version = "0.11", optional = true }
 gettext_system = { package = "gettext", version = "0.4", optional = true }


### PR DESCRIPTION
None of the changes after 1.0.0 are actually needed, and I would like to link against https://packages.debian.org/librust-arc-swap-dev which is 1.5.1.