### PR TITLE
Use domain override in fl! macro

### DIFF
--- a/i18n-embed-fl/src/lib.rs
+++ b/i18n-embed-fl/src/lib.rs
@@ -343,7 +343,7 @@ pub fn fl(input: TokenStream) -> TokenStream {
     let manifest = find_crate::Manifest::new().expect("Error reading Cargo.toml");
     let current_crate_package = manifest.crate_package().expect("Error parsing Cargo.toml");
 
-    let domain = current_crate_package.name;
+    let mut domain = current_crate_package.name;
 
     let domain_data = if let Some(domain_data) = DOMAINS.get(&domain) {
         domain_data
@@ -374,6 +374,9 @@ pub fn fl(input: TokenStream) -> TokenStream {
                         along with its required `assets_dir`.";
             }
         });
+
+        // we will only override the domain in entry if it did not exist before
+        domain = fluent_config.domain.unwrap_or(domain);
 
         let assets_dir = Path::new(&crate_paths.crate_dir).join(fluent_config.assets_dir);
         let assets = FileSystemAssets::new(assets_dir);


### PR DESCRIPTION
`domain` from Cargo.toml was unused in the `fl!` macro. It seems like this was an oversight #106 

When a domain is not specified, the fl! macro increases build times slightly because we have to open the config file and translation files for every macro invokation. I didn't see any increase in build times but I can make some improvements if that's a concern for this merge request. 