### PR TITLE
fix: bump `gettext-rs` and `gettext-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49ea8a8fad198aaa1f9655a2524b64b70eb06b2f3ff37da407566c93054f364"
+checksum = "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.21.3"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63ce2e00f56a206778276704bbe38564c8695249fdc8f354b4ef71c57c3839d"
+checksum = "bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661"
 dependencies = [
  "cc",
  "temp-dir",


### PR DESCRIPTION
seeing some source build failure as

```
  --- stderr
  configure: WARNING: unknown target-version 21, please update gt_JAVACOMP macro
  /private/tmp/ta69a-0/gettext/libtextstyle/lib/obstack.c:351:31: error: incompatible function pointer types initializing 'void (*)(void) __attribute__((noreturn))' with an expression of type 'void (void)' [-Wincompatible-function-pointer-types]
    351 | __attribute_noreturn__ void (*obstack_alloc_failed_handler) (void)
        |                               ^
    352 |   = print_and_abort;
        |     ~~~~~~~~~~~~~~~
  1 error generated.
```

bumping `gettext-rs` and `gettext-sys` crates