### PR TITLE
update #131: Make dashmap optional.

### DIFF
--- a/i18n-embed-fl/Cargo.toml
+++ b/i18n-embed-fl/Cargo.toml
@@ -34,5 +34,5 @@ pretty_assertions = { workspace = true }
 rust-embed = { workspace = true }
 
 [features]
-# Enables more performant version of the crate. May download extra dependencies.
-performance = ["dep:dashmap"]
+# Uses dashmap implementation for `fl!()` macro lookups.
+dashmap = ["dep:dashmap"]

--- a/i18n-embed-fl/Cargo.toml
+++ b/i18n-embed-fl/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-dashmap = "6.0"
+dashmap = { version = "6.0", optional = true }
 find-crate = { workspace = true }
 fluent = { workspace = true }
 fluent-syntax = { workspace = true }
@@ -32,3 +32,7 @@ doc-comment = { workspace = true }
 env_logger = { workspace = true }
 pretty_assertions = { workspace = true }
 rust-embed = { workspace = true }
+
+[features]
+# Enables more performant version of the crate. May download extra dependencies.
+performance = ["dep:dashmap"]


### PR DESCRIPTION
As per #131, I gave a shot at making `dashmap` optional.

You can activate the `dashmap` implementation by activating the feature flag `performance` in your `Cargo.toml` file. This will cause an additional usage of `dashmap`.

Alternatively, you may compile directly with
```
cargo build --features performance
```

Let me know if you want to name the feature differently or if there are better ways to approach this. 