### PR TITLE
Custom config path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,18 +80,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bin"
 version = "0.1.0"
 dependencies = [
+ "custom-config-path",
  "env_logger",
  "i18n-embed",
  "library-fluent",
@@ -228,6 +220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom-config-path"
+version = "0.1.0"
+dependencies = [
+ "i18n-embed",
+ "i18n-embed-fl",
+ "once_cell",
+ "rust-embed",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +237,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -362,12 +364,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-crate"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -548,6 +556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "i18n-build"
 version = "0.10.3"
 dependencies = [
@@ -567,11 +581,11 @@ dependencies = [
 name = "i18n-config"
 version = "0.4.8"
 dependencies = [
- "basic-toml",
  "log",
  "serde",
  "serde_derive",
  "thiserror 1.0.69",
+ "toml 0.9.4",
  "unic-langid",
 ]
 
@@ -635,6 +649,16 @@ dependencies = [
  "quote",
  "rust-embed",
  "syn",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1120,6 +1144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1306,45 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tr"
@@ -1606,6 +1678,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "i18n-embed/examples/library-fluent",
     "i18n-embed/examples/desktop-bin",
     "i18n-embed-fl/examples/web-server",
+    "i18n-embed/examples/custom-config-path",
 ]
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ fn example(file: String) {
 
 ### Minimal Configuration
 
-You will need to create an `i18n.toml` configuration in the root directory of your crate. A minimal configuration for a binary crate to be localized to Spanish and Japanese using the `gettext` system would be:
+You will need to create an `i18n.toml` configuration. By default this is in the root directory of your crate, but it can be [configured](#configuration) to use another location.
+
+A minimal configuration for a binary crate to be localized to Spanish and Japanese using the `gettext` system would be:
 
 ```toml
 # (Required) The language identifier of the language used in the
@@ -246,6 +248,15 @@ use_fuzzy = false
 # The paths inside the assets directory should be structured like so:
 # `assets_dir/{language}/{domain}.ftl`
 assets_dir = "i18n"
+```
+
+Available configuration options for `Cargo.toml`:
+
+```toml
+[package.metadata.cargo-i18n]
+# (Optional) The path to the i18n configuration file used by cargo-i18n and i18n-embed.
+# The path is relative to the crate root.
+config-path = "i18n.toml"
 ```
 
 ## System Requirements

--- a/i18n-build/src/gettext_impl/mod.rs
+++ b/i18n-build/src/gettext_impl/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::error::{PathError, PathType};
 use crate::util;
-use i18n_config::{Crate, GettextConfig, I18nConfigError};
+use i18n_config::{Crate, GettextConfig, I18nCargoMetadata, I18nConfigError};
 
 use std::ffi::OsStr;
 use std::fs::{create_dir_all, File};
@@ -407,11 +407,13 @@ pub fn run(crt: &Crate) -> Result<()> {
                 .subcrates
                 .iter()
                 .map(|subcrate_path| {
-                    Crate::from(
-                        subcrate_path.clone(),
-                        Some(crt),
-                        crt.config_file_path.clone(),
-                    )
+                    let subcrate_config_path =
+                        I18nCargoMetadata::from_cargo_manifest(subcrate_path.join("Cargo.toml"))
+                            .ok()
+                            .and_then(|m| m.config_path)
+                            .map(PathBuf::from)
+                            .unwrap_or(PathBuf::from("i18n.toml"));
+                    Crate::from(subcrate_path.clone(), Some(crt), subcrate_config_path)
                 })
                 .collect();
 

--- a/i18n-build/src/gettext_impl/mod.rs
+++ b/i18n-build/src/gettext_impl/mod.rs
@@ -432,9 +432,21 @@ pub fn run(crt: &Crate) -> Result<()> {
     };
 
     let src_dir = crt.path.join("src");
-    let pot_dir = config_crate.path.join(gettext_config.pot_dir());
-    let po_dir = config_crate.path.join(gettext_config.po_dir());
-    let mo_dir = config_crate.path.join(gettext_config.mo_dir());
+    let pot_dir = config_crate
+        .config_file_path
+        .parent()
+        .unwrap_or(&config_crate.path)
+        .join(gettext_config.pot_dir());
+    let po_dir = config_crate
+        .config_file_path
+        .parent()
+        .unwrap_or(&config_crate.path)
+        .join(gettext_config.po_dir());
+    let mo_dir = config_crate
+        .config_file_path
+        .parent()
+        .unwrap_or(&config_crate.path)
+        .join(gettext_config.mo_dir());
 
     // perform string extraction if required
     if do_xtr {

--- a/i18n-config/Cargo.toml
+++ b/i18n-config/Cargo.toml
@@ -17,8 +17,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 log = { workspace = true }
-basic-toml = "0.1"
 serde = { workspace = true, features = ["derive"] }
 serde_derive = { workspace = true }
 thiserror = { workspace = true }
+toml = "0.9.4"
 unic-langid = { workspace = true, features = ["serde"] }

--- a/i18n-embed-fl/src/lib.rs
+++ b/i18n-embed-fl/src/lib.rs
@@ -439,7 +439,13 @@ pub fn fl(input: TokenStream) -> TokenStream {
         // Use the domain override in the configuration.
         let domain = fluent_config.domain.unwrap_or(domain);
 
-        let assets_dir = Path::new(&crate_paths.crate_dir).join(fluent_config.assets_dir);
+        let assets_dir = Path::new(
+            &crate_paths
+                .i18n_config_file
+                .parent()
+                .unwrap_or(&crate_paths.crate_dir),
+        )
+        .join(fluent_config.assets_dir);
         let assets = FileSystemAssets::try_new(assets_dir).unwrap();
 
         let fallback_language: LanguageIdentifier = config.fallback_language;

--- a/i18n-embed/examples/custom-config-path/Cargo.toml
+++ b/i18n-embed/examples/custom-config-path/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "custom-config-path"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+i18n-embed = { workspace = true, features = ["fluent-system", "autoreload"] }
+i18n-embed-fl = { workspace = true }
+once_cell = { workspace = true }
+rust-embed = { workspace = true }
+
+[package.metadata.cargo-i18n]
+config-path = "misc/i18n.toml"

--- a/i18n-embed/examples/custom-config-path/i18n/en/custom_config_path.ftl
+++ b/i18n-embed/examples/custom-config-path/i18n/en/custom_config_path.ftl
@@ -1,0 +1,1 @@
+hello-world = Hello World!

--- a/i18n-embed/examples/custom-config-path/i18n/eo/custom_config_path.ftl
+++ b/i18n-embed/examples/custom-config-path/i18n/eo/custom_config_path.ftl
@@ -1,0 +1,1 @@
+hello-world = Saluton mondo!

--- a/i18n-embed/examples/custom-config-path/i18n/fr/custom_config_path.ftl
+++ b/i18n-embed/examples/custom-config-path/i18n/fr/custom_config_path.ftl
@@ -1,0 +1,1 @@
+hello-world = Bonjour le monde!

--- a/i18n-embed/examples/custom-config-path/misc/i18n.toml
+++ b/i18n-embed/examples/custom-config-path/misc/i18n.toml
@@ -1,0 +1,12 @@
+# (Required) The language identifier of the language used in the
+# source code for gettext system, and the primary fallback language
+# (for which all strings must be present) when using the fluent
+# system.
+fallback_language = "en"
+
+# (Optional) Use the fluent localization system.
+[fluent]
+# (Required) The path to the assets directory.
+# The paths inside the assets directory should be structured like so:
+# `assets_dir/{language}/{domain}.ftl`
+assets_dir = "../i18n"

--- a/i18n-embed/examples/custom-config-path/src/lib.rs
+++ b/i18n-embed/examples/custom-config-path/src/lib.rs
@@ -1,0 +1,48 @@
+use i18n_embed::{
+    DefaultLocalizer, LanguageLoader, RustEmbedNotifyAssets,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
+};
+use i18n_embed_fl::fl;
+use once_cell::sync::Lazy;
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "i18n/"]
+pub struct LocalizationsEmbed;
+
+pub static LOCALIZATIONS: Lazy<RustEmbedNotifyAssets<LocalizationsEmbed>> = Lazy::new(|| {
+    RustEmbedNotifyAssets::new(std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("i18n/"))
+});
+
+static LANGUAGE_LOADER: Lazy<FluentLanguageLoader> = Lazy::new(|| {
+    let loader: FluentLanguageLoader = fluent_language_loader!();
+
+    // Load the fallback language by default so that users of the
+    // library don't need to if they don't care about localization.
+    loader
+        .load_fallback_language(&*LOCALIZATIONS)
+        .expect("Error while loading fallback language");
+
+    loader
+});
+
+macro_rules! fl {
+    ($message_id:literal) => {{
+        i18n_embed_fl::fl!($crate::LANGUAGE_LOADER, $message_id)
+    }};
+
+    ($message_id:literal, $($args:expr),*) => {{
+        i18n_embed_fl::fl!($crate::LANGUAGE_LOADER, $message_id, $($args), *)
+    }};
+}
+
+/// Get the hello world statement in whatever the currently selected
+/// localization is.
+pub fn hello_world() -> String {
+    fl!("hello-world")
+}
+
+// Get the `Localizer` to be used for localizing this library.
+pub fn localizer() -> DefaultLocalizer<'static> {
+    DefaultLocalizer::new(&*LANGUAGE_LOADER, &*LOCALIZATIONS)
+}

--- a/i18n-embed/examples/desktop-bin/Cargo.toml
+++ b/i18n-embed/examples/desktop-bin/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["standard_config"]
+standard_config = ["dep:library-fluent"]
+nonstandard_config = ["dep:custom-config-path"]
+
 [dependencies]
-library-fluent = { path = "../library-fluent/" }
+library-fluent = { path = "../library-fluent/", optional = true }
+custom-config-path = { path = "../custom-config-path", optional = true }
 i18n-embed = { workspace = true, features = ["fluent-system", "desktop-requester"]}
 env_logger = "0.11.3"

--- a/i18n-embed/examples/desktop-bin/README.md
+++ b/i18n-embed/examples/desktop-bin/README.md
@@ -2,4 +2,6 @@
 
 This example demonstrates how to use a library localized with [i18n-embed](../../i18n-embed/) and the `DesktopLanguageRequester` in a desktop CLI application.
 
+It can use either of two backends: a library with an `i18n.toml` file in the crate root, or an identical library with the `i18n.toml` in a subdirectory of the crate root. The first is used by default; to run the second, use `cargo run --no-default-features --features nonstandard_config`.
+
 On unix, you can override the detected language by setting the `LANG` environment variable before running. The two available languages in the `library-fluent` example are `fr`, `eo`, and `en` (the fallback).

--- a/i18n-embed/examples/desktop-bin/src/main.rs
+++ b/i18n-embed/examples/desktop-bin/src/main.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
 use i18n_embed::{DesktopLanguageRequester, Localizer};
+
+#[cfg(feature = "nonstandard_config")]
+use custom_config_path::{hello_world, localizer};
+#[cfg(feature = "standard_config")]
 use library_fluent::{hello_world, localizer};
 
 fn main() {


### PR DESCRIPTION
Closes #155.

Adds the ability to specify a custom location for the i18n configuration file via Cargo metadata. A new example was added at `i18n-embed/examples/custom-config-path` to showcase the feature, and I have tested it with i18n-embed-fl, i18n-embed, a subcrate using gettext, and the cargo i18n command.