### PR TITLE
fix(fluent): memoize FluentLanguageLoader::get

### DIFF
--- a/i18n-embed/src/fluent.rs
+++ b/i18n-embed/src/fluent.rs
@@ -85,6 +85,7 @@ pub struct FluentLanguageLoader {
     inner: ArcSwap<FluentLanguageLoaderInner>,
     domain: String,
     fallback_language: unic_langid::LanguageIdentifier,
+    string_cache: parking_lot::RwLock<HashMap<String, String>>,
 }
 
 impl FluentLanguageLoader {
@@ -111,6 +112,7 @@ impl FluentLanguageLoader {
             })),
             domain: domain.into(),
             fallback_language,
+            string_cache: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 
@@ -132,7 +134,15 @@ impl FluentLanguageLoader {
 
     /// Get a localized message referenced by the `message_id`.
     pub fn get(&self, message_id: &str) -> String {
-        self.get_args_fluent(message_id, None)
+        let cache = self.string_cache.read();
+        if let Some(s) = cache.get(message_id) {
+            return s.clone();
+        }
+        let value = self.get_args_fluent(message_id, None);
+        self.string_cache
+            .write()
+            .insert(message_id.to_owned(), value.clone());
+        value
     }
 
     /// A non-generic version of [FluentLanguageLoader::get_args()].
@@ -477,6 +487,7 @@ impl FluentLanguageLoader {
             })),
             domain: self.domain.clone(),
             fallback_language: self.fallback_language.clone(),
+            string_cache: parking_lot::RwLock::new(HashMap::new()),
         }
     }
 
@@ -576,6 +587,8 @@ impl LanguageLoader for FluentLanguageLoader {
                 Ok(LanguageBundle::new(language.clone(), resource))
             }).collect::<Result<Vec<_>, I18nEmbedError>>()
         }).collect::<Result<_, I18nEmbedError>>()?;
+
+        self.string_cache.write().clear();
 
         self.inner.swap(Arc::new(FluentLanguageLoaderInner {
             current_languages: CurrentLanguages {


### PR DESCRIPTION
After profiling a number of COSMIC applications, I determined that localization was responsible for a not insignificant amount of idle CPU and disk IO. This is easily fixed by memoizing `FluentLanguageLoader::get`.