### PR TITLE
fix(i18n-embed-fl): switch to proc-macro-error3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
  "i18n-config",
  "i18n-embed",
  "pretty_assertions",
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "rust-embed",
@@ -946,22 +946,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "be5bfc63c4dc85083c9daaf7112d0261701d4058677c3bff7f2afc44e30ef3e1"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "dd0d42490f6b7b143eef32b9e3522e42bf25dadc02c69ed72236f80adb949b5c"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
  "syn",

--- a/i18n-embed-fl/Cargo.toml
+++ b/i18n-embed-fl/Cargo.toml
@@ -19,7 +19,7 @@ fluent-syntax = { workspace = true }
 i18n-config = { workspace = true }
 i18n-embed = { workspace = true, features = ["fluent-system", "filesystem-assets"]}
 proc-macro2 = { workspace = true }
-proc-macro-error2 = "2.0.1"
+proc-macro-error3 = "3.0"
 quote = { workspace = true }
 strsim = "0.11"
 unic-langid = { workspace = true }

--- a/i18n-embed-fl/src/lib.rs
+++ b/i18n-embed-fl/src/lib.rs
@@ -3,7 +3,7 @@ use fluent::{FluentAttribute, FluentMessage, FluentResource};
 use fluent_syntax::ast::{CallArguments, Expression, InlineExpression, Pattern, PatternElement};
 use i18n_embed::{fluent::FluentLanguageLoader, FileSystemAssets, LanguageLoader};
 use proc_macro::TokenStream;
-use proc_macro_error2::{abort, emit_error, proc_macro_error};
+use proc_macro_error3::{abort, emit_error, proc_macro_error};
 use quote::quote;
 use std::{
     collections::{HashMap, HashSet},


### PR DESCRIPTION
Fixes #172.

proc-macro-error2 is unmaintained and its repository has been archived, see RUSTSEC-2026-0173. proc-macro-error3 is a maintained fork with the same API, so the change is just the dependency rename in Cargo.toml and the import in lib.rs.

Ran cargo build and cargo test for i18n-embed-fl locally, everything still passes.